### PR TITLE
Replace STEM by STEAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 #  Sustainable STEAM-driven Development of Regions
 
-We are uncovering better ways of developing regions through STEM by doing it and helping others do it.
+We are uncovering better ways of developing regions through STEAM by doing it and helping others do it.
 
 Through this work we have come to value:
 
 <p style="text-align: center;">
 Alliances and collaborations over knowledge silos<br>
-Attracting sustainable STEM talent over wasting it outside the region<br>
+Attracting sustainable STEAM talent over wasting it outside the region<br>
 Embrace innovation over conservative strategies<br>
-Promote sustainable STEM development over speculative bubbles<br>
+Promote sustainable STEAM development over speculative bubbles<br>
 People and relationships over goals and objectives<br>
 Think beyond the limits established over initiatives and conformist thoughts<br>
 </p>
@@ -17,9 +17,9 @@ That is, while there is value in the items on the right, we value the items on t
 
 We, as implementers, follow these principles:
 
-1. The highest priority is to make the represented region visible on the international STEM landscapes.
+1. The highest priority is to make the represented region visible on the international STEAM landscapes.
 1. All initiatives are driven by transparency, honesty, and respect people.
-1. Promote the sustainable development, within the region we represent, through STEM.
+1. Promote the sustainable development, within the region we represent, through STEAM.
 1. Define a clear range of alignment options which must be followed by the participants.
 1. The promoted initiatives are meant to have the highest impact possible.
 1. Exchange among people and cultures must be encouraged.


### PR DESCRIPTION
Old word STEM was remaining in the manifesto and it should be replaced by STEAM